### PR TITLE
feat: Add callgraph_creator executable and update CMake configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -614,13 +614,7 @@ set_tests_properties(datacrumbs PROPERTIES DEPENDS ${PROJECT_NAME})
 
 add_subdirectory(tools)
 add_subdirectory(tests)
-add_executable(callgraph_creator
-    tools/callgraph.cpp
-)
-install(
-    TARGETS callgraph_creator
-    RUNTIME DESTINATION ${DATACRUMBS_INSTALL_BINARYDIR}/tools
-)
+
 add_test(NAME test_simple_dd
     COMMAND bash -c "dd if=/dev/zero of=/tmp/img_temp.bat bs=1M count=16"
 )

--- a/src/datacrumbs/explorer/mechanism/elf_capture.cpp
+++ b/src/datacrumbs/explorer/mechanism/elf_capture.cpp
@@ -3,7 +3,12 @@
 namespace datacrumbs {
 
 ElfSymbolExtractor::ElfSymbolExtractor(const std::string& path, bool include_offsets)
-    : fd_(-1), data_(nullptr), size_(0), include_offsets_(include_offsets) {
+    : fd_(-1), data_(nullptr), size_(0), include_offsets_(include_offsets), base_address_(0),
+      kExcludedFunctions({
+          "_init",
+          "_fini",
+          "_start"
+      }) {
   DC_LOG_TRACE("ElfSymbolExtractor: constructor start for file: %s", path.c_str());
   fd_ = open(path.c_str(), O_RDONLY);
   if (fd_ < 0) {
@@ -125,16 +130,20 @@ std::vector<std::string> ElfSymbolExtractor::extract_symbols() {
 
   std::vector<std::string> symbols;
   for (const auto& pair : symbols_map) {
+    // Skip if symbol is in kExcludedFunctions
+    if (kExcludedFunctions.find(pair.first) != kExcludedFunctions.end()) {
+      continue;
+    }
     if (pair.second.size() > 1) {
       DC_LOG_WARN("Symbol %s has multiple offsets, using all occurrences", pair.first.c_str());
       for (const auto& offset : pair.second) {
-        symbols.push_back(pair.first + ":" + offset);
+      symbols.push_back(pair.first + ":" + offset);
       }
     } else {
       if (include_offsets_) {
-        symbols.push_back(pair.first + ":" + *pair.second.begin());
+      symbols.push_back(pair.first + ":" + *pair.second.begin());
       } else {
-        symbols.push_back(pair.first);
+      symbols.push_back(pair.first);
       }
     }
   }

--- a/src/datacrumbs/explorer/mechanism/elf_capture.h
+++ b/src/datacrumbs/explorer/mechanism/elf_capture.h
@@ -55,6 +55,7 @@ class ElfSymbolExtractor {
   bool include_offsets_;   ///< Whether to include offsets in the extraction.
   uint64_t base_address_;  ///< Base address for relative symbols (0 for ET_DYN, entry point for
                            ///< ET_EXEC).
+  std::unordered_set<std::string> kExcludedFunctions; ///< Set of functions to exclude from extraction.
 };
 
 }  // namespace datacrumbs

--- a/src/datacrumbs/explorer/probe_explorer.cpp
+++ b/src/datacrumbs/explorer/probe_explorer.cpp
@@ -7,6 +7,7 @@ namespace datacrumbs {
 ProbeExplorer::ProbeExplorer(int argc, char** argv) {
   DC_LOG_TRACE("ProbeExplorer::ProbeExplorer - start");
   configManager_ = datacrumbs::Singleton<ConfigurationManager>::get_instance(argc, argv);
+  has_invalid_probes_ = false;
   DC_LOG_TRACE("ProbeExplorer::ProbeExplorer - end");
 }
 
@@ -63,7 +64,6 @@ std::vector<std::shared_ptr<Probe>> ProbeExplorer::extractProbes() {
   }
 
   std::vector<std::shared_ptr<Probe>> probes;
-
   // Iterate over all capture probes from configuration
   for (const auto& capture_probe : configManager_->capture_probes) {
     std::vector<std::string> functionNames;
@@ -249,10 +249,14 @@ std::vector<std::shared_ptr<Probe>> ProbeExplorer::extractProbes() {
     // Validate the probe before adding
     if (!probe->validate()) {
       DC_LOG_ERROR("Probe validation failed for: %s", probe->name.c_str());
+      has_invalid_probes_ = true;
       continue;  // Skip invalid probes
     }
     DC_LOG_INFO("Valid probe extracted: %s", probe->name.c_str());
     probes.push_back(probe);
+  }
+  if (has_invalid_probes_) {
+    DC_LOG_ERROR("One or more probes failed validation. Please check the logs above.");
   }
   DC_LOG_TRACE("ProbeExplorer::extractProbes - end");
   return probes;
@@ -345,5 +349,9 @@ int main(int argc, char** argv) {
   timer.pauseTime();  // Stop timer and accumulate elapsed time
   DC_LOG_PRINT("Elapsed time in Probe Explorer: %f seconds", timer.getElapsedTime());
   DC_LOG_TRACE("main - end");
+  if (explorer.has_invalid_probes_) {
+    DC_LOG_ERROR("Probe exploration completed with errors due to invalid probes.");
+    return 1;  // Indicate error due to invalid probes
+  }
   return 0;
 }

--- a/src/datacrumbs/explorer/probe_explorer.h
+++ b/src/datacrumbs/explorer/probe_explorer.h
@@ -38,6 +38,8 @@ class ProbeExplorer {
   // Returns a vector of shared pointers to Probe objects
   std::vector<std::shared_ptr<Probe>> writeProbesToJson();
 
+  bool has_invalid_probes_ = false;  // Flag to indicate if any invalid probes were found
+
  private:
   // Configuration manager instance for managing configuration settings
   std::shared_ptr<ConfigurationManager> configManager_;

--- a/src/datacrumbs/generator/generator.cpp
+++ b/src/datacrumbs/generator/generator.cpp
@@ -225,6 +225,19 @@ int ProbeGenerator::run() {
 
     json_object_put(jarray);  // free memory
     DC_LOG_TRACE("ProbeExplorer::writeProbesToJson - end");
+  } else {
+    DC_LOG_INFO("No manual probes were added.");
+    // Remove existing manual probe file if it exists
+    std::error_code ec;
+    if (std::filesystem::exists(configManager_->manual_probe_path, ec)) {
+      std::filesystem::remove(configManager_->manual_probe_path, ec);
+      if (ec) {
+        DC_LOG_ERROR("Failed to remove file: %s", configManager_->manual_probe_path.c_str());
+      } else {
+        DC_LOG_INFO("Removed existing manual probe file: %s",
+                    configManager_->manual_probe_path.c_str());
+      }
+    }
   }
   // Append all generated probe files as includes to generated.bpf.c
   const char* gen_path = DATACRUMBS_SRC_GEN_PATH;

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -6,3 +6,6 @@ find_package(json-c REQUIRED)
 add_executable(aggregate_trace aggregate_trace.cpp)
 
 target_link_libraries(aggregate_trace PRIVATE json-c::json-c ZLIB::ZLIB)
+
+add_executable(callgraph_creator callgraph_vis.cpp)
+target_link_libraries(callgraph_creator PRIVATE json-c::json-c ZLIB::ZLIB)


### PR DESCRIPTION
Fixes MPI programs with `_start` fail
Fixes #68

Fixes Add comment to commented lines or remove them Fixes Clean manual probes during compilation
Fixes #65
Fixes Ability to skip if there are no probes
Fixes #67