### PR TITLE
refactor: Improve duplicate function name handling in ProbeGenerator

### DIFF
--- a/src/datacrumbs/explorer/probe_explorer.cpp
+++ b/src/datacrumbs/explorer/probe_explorer.cpp
@@ -62,7 +62,7 @@ std::vector<std::shared_ptr<Probe>> ProbeExplorer::extractProbes() {
       DC_LOG_DEBUG("  Excluded Function: %s", func.c_str());
     }
   }
-
+  static std::unordered_set<std::string> global_function_names;
   std::vector<std::shared_ptr<Probe>> probes;
   // Iterate over all capture probes from configuration
   for (const auto& capture_probe : configManager_->capture_probes) {
@@ -98,21 +98,37 @@ std::vector<std::shared_ptr<Probe>> ProbeExplorer::extractProbes() {
         if (auto headerProbe = std::static_pointer_cast<HeaderCaptureProbe>(capture_probe)) {
           DC_LOG_DEBUG("Header Name: %s", headerProbe->file.c_str());
           functionNames = HeaderFunctionExtractor(headerProbe->file).extractFunctionNames();
-          if (capture_probe->probe_type == ProbeType::KPROBE) {
-            DC_LOG_DEBUG("KPROBE: Extracting symbols from header...");
-            const auto& ksym_functions =
-                datacrumbs::Singleton<KSymCapture>::get_instance()->functions_;
-            std::vector<std::string> validFunctionNames;
-            for (const auto& name : functionNames) {
-              if (ksym_functions.find(name) != ksym_functions.end()) {
-                validFunctionNames.push_back(name);
-              } else {
-                DC_LOG_WARN("Function '%s' not found in KSymCapture functions, skipping.",
-                            name.c_str());
-              }
+          std::vector<std::string> validFunctionNames;
+          for (const auto& name : functionNames) {
+            DC_LOG_INFO("[ProbeGenerator] Function name '%s' from %s.", name.c_str(),
+                        capture_probe->name.c_str());
+            auto combined_name = name;
+            // Check and insert into global set to avoid duplicates
+            if (!global_function_names.insert(combined_name).second) {
+              DC_LOG_WARN(
+                  "[ProbeGenerator] Function name '%s' already processed. Skipping duplicate "
+                  "from %s.",
+                  name.c_str(), capture_probe->name.c_str());
+              continue;
             }
-            functionNames = std::move(validFunctionNames);
+            validFunctionNames.push_back(name);
           }
+          functionNames = std::move(validFunctionNames);
+        }
+        if (capture_probe->probe_type == ProbeType::KPROBE) {
+          DC_LOG_DEBUG("KPROBE: Extracting symbols from header...");
+          const auto& ksym_functions =
+              datacrumbs::Singleton<KSymCapture>::get_instance()->functions_;
+          std::vector<std::string> validFunctionNames;
+          for (const auto& name : functionNames) {
+            if (ksym_functions.find(name) != ksym_functions.end()) {
+              validFunctionNames.push_back(name);
+            } else {
+              DC_LOG_WARN("Function '%s' not found in KSymCapture functions, skipping.",
+                          name.c_str());
+            }
+          }
+          functionNames = std::move(validFunctionNames);
         }
         break;
       case CaptureType::BINARY:
@@ -126,6 +142,20 @@ std::vector<std::shared_ptr<Probe>> ProbeExplorer::extractProbes() {
             if (auto uprobe = std::dynamic_pointer_cast<UProbe>(probe)) {
               uprobe->binary_path = binaryProbe->file;
               uprobe->include_offsets = binaryProbe->include_offsets;
+              std::vector<std::string> validFunctionNames;
+              for (const auto& name : functionNames) {
+                auto combined_name = binaryProbe->file + "_" + name;
+                // Check and insert into global set to avoid duplicates
+                if (!global_function_names.insert(combined_name).second) {
+                  DC_LOG_WARN(
+                      "[ProbeGenerator] Function name '%s' already processed. Skipping duplicate "
+                      "from %s.",
+                      name.c_str(), capture_probe->name.c_str());
+                  continue;
+                }
+                validFunctionNames.push_back(name);
+              }
+              functionNames = std::move(validFunctionNames);
             }
           }
         }
@@ -138,8 +168,24 @@ std::vector<std::shared_ptr<Probe>> ProbeExplorer::extractProbes() {
             if (auto usdt_probe = std::dynamic_pointer_cast<USDTProbe>(probe)) {
               usdt_probe->binary_path = usdtProbe->binary_path;
               usdt_probe->provider = usdtProbe->provider;
+
+              functionNames = USDTFunctionExtractor(usdtProbe->provider).extractFunctionNames();
+              std::vector<std::string> validFunctionNames;
+              for (const auto& name : functionNames) {
+                auto combined_name =
+                    usdtProbe->binary_path + "_" + usdtProbe->provider + "_" + name;
+                // Check and insert into global set to avoid duplicates
+                if (!global_function_names.insert(combined_name).second) {
+                  DC_LOG_WARN(
+                      "[ProbeGenerator] Function name '%s' already processed. Skipping duplicate "
+                      "from %s.",
+                      name.c_str(), capture_probe->name.c_str());
+                  continue;
+                }
+                validFunctionNames.push_back(name);
+              }
+              functionNames = std::move(validFunctionNames);
             }
-            functionNames = USDTFunctionExtractor(usdtProbe->provider).extractFunctionNames();
           }
         }
         break;
@@ -148,6 +194,20 @@ std::vector<std::shared_ptr<Probe>> ProbeExplorer::extractProbes() {
         if (auto ksymProbe = std::static_pointer_cast<KernelCaptureProbe>(capture_probe)) {
           functionNames = datacrumbs::Singleton<KSymCapture>::get_instance()->getFunctionsByRegex(
               ksymProbe->regex);
+          std::vector<std::string> validFunctionNames;
+          for (const auto& name : functionNames) {
+            auto combined_name = name;
+            // Check and insert into global set to avoid duplicates
+            if (!global_function_names.insert(combined_name).second) {
+              DC_LOG_WARN(
+                  "[ProbeGenerator] Function name '%s' already processed. Skipping duplicate "
+                  "from %s.",
+                  name.c_str(), capture_probe->name.c_str());
+              continue;
+            }
+            validFunctionNames.push_back(name);
+          }
+          functionNames = std::move(validFunctionNames);
         }
         break;
       case CaptureType::CUSTOM:
@@ -194,6 +254,22 @@ std::vector<std::shared_ptr<Probe>> ProbeExplorer::extractProbes() {
             custom_probe->start_event_id = customProbe->start_event_id;
             custom_probe->process_header = customProbe->process_header;
             custom_probe->event_type = customProbe->event_type;
+            std::vector<std::string> validFunctionNames;
+            for (const auto& name : functionNames) {
+              DC_LOG_DEBUG("[ProbeGenerator] Function name '%s' from %s.", name.c_str(),
+                           capture_probe->name.c_str());
+              auto combined_name = name;
+              // Check and insert into global set to avoid duplicates
+              if (!global_function_names.insert(combined_name).second) {
+                DC_LOG_WARN(
+                    "[ProbeGenerator] Function name '%s' already processed. Skipping duplicate "
+                    "from %s.",
+                    name.c_str(), capture_probe->name.c_str());
+                continue;
+              }
+              validFunctionNames.push_back(name);
+            }
+            functionNames = std::move(validFunctionNames);
           }
         }
         break;

--- a/src/datacrumbs/generator/generator.cpp
+++ b/src/datacrumbs/generator/generator.cpp
@@ -72,14 +72,6 @@ int ProbeGenerator::run() {
     // Iterate over each function in the probe
     for (size_t func_index = 0; func_index < probe.functions.size(); ++func_index) {
       const auto& func = probe.functions[func_index];
-      auto combined_name = probe.name + "_" + func;
-      // Check and insert into global set to avoid duplicates
-      if (!global_function_names.insert(combined_name).second) {
-        DC_LOG_WARN(
-            "[ProbeGenerator] Function name '%s' already processed. Skipping duplicate from %s.",
-            func.c_str(), probe.name.c_str());
-        continue;
-      }
 
       int current_event_id = 0;
       if (probe.type != ProbeType::CUSTOM) {
@@ -98,6 +90,15 @@ int ProbeGenerator::run() {
       // Generate code based on probe type
       switch (probe.type) {
         case ProbeType::KPROBE: {
+          auto combined_name = func;
+          // Check and insert into global set to avoid duplicates
+          if (!global_function_names.insert(combined_name).second) {
+            DC_LOG_WARN(
+                "[ProbeGenerator] Function name '%s' already processed. Skipping duplicate from "
+                "%s.",
+                func.c_str(), probe.name.c_str());
+            continue;
+          }
           DC_LOG_DEBUG("[ProbeGenerator] Using KProbeGenerator for function: %s (event_id: %d)",
                        func.c_str(), current_event_id);
           KProbeGenerator generator(current_event_id, func);
@@ -119,6 +120,15 @@ int ProbeGenerator::run() {
             function_name = func;
             offset = "";
           }
+          auto combined_name = uprobe.binary_path + "_" + function_name + "_" + offset;
+          // Check and insert into global set to avoid duplicates
+          if (!global_function_names.insert(combined_name).second) {
+            DC_LOG_WARN(
+                "[ProbeGenerator] Function name '%s' already processed. Skipping duplicate from "
+                "%s.",
+                func.c_str(), probe.name.c_str());
+            continue;
+          }
           if (is_manual) {
             DC_LOG_DEBUG("[ProbeGenerator] Adding manual uprobe for function: %s", func.c_str());
             manual_probe->functions.push_back(std::to_string(current_event_id));
@@ -133,17 +143,45 @@ int ProbeGenerator::run() {
           DC_LOG_DEBUG("[ProbeGenerator] Using SyscallGenerator for function: %s (event_id: %d)",
                        func.c_str(), current_event_id);
           SyscallGenerator syscall_gen(current_event_id, func);
+          auto combined_name = func;
+          // Check and insert into global set to avoid duplicates
+          if (!global_function_names.insert(combined_name).second) {
+            DC_LOG_WARN(
+                "[ProbeGenerator] Function name '%s' already processed. Skipping duplicate from "
+                "%s.",
+                func.c_str(), probe.name.c_str());
+            continue;
+          }
           ss << syscall_gen.generate().str() << std::endl;
+
           break;
         }
         case ProbeType::USDT: {
           DC_LOG_DEBUG("[ProbeGenerator] Using USDTGenerator for function: %s (event_id: %d)",
                        func.c_str(), current_event_id);
           auto usdt = USDTProbe::fromJson(jprobe);
+          auto combined_name = usdt.binary_path + "_" + usdt.provider + "_" + func;
+          // Check and insert into global set to avoid duplicates
+          if (!global_function_names.insert(combined_name).second) {
+            DC_LOG_WARN(
+                "[ProbeGenerator] Function name '%s' already processed. Skipping duplicate from "
+                "%s.",
+                func.c_str(), probe.name.c_str());
+            continue;
+          }
           USDTGenerator usdt_gen(current_event_id, func, usdt.binary_path, usdt.provider);
           ss << usdt_gen.generate().str() << std::endl;
         } break;
         case ProbeType::CUSTOM: {
+          auto combined_name = func;
+          // Check and insert into global set to avoid duplicates
+          if (!global_function_names.insert(combined_name).second) {
+            DC_LOG_WARN(
+                "[ProbeGenerator] Function name '%s' already processed. Skipping duplicate from "
+                "%s.",
+                func.c_str(), probe.name.c_str());
+            continue;
+          }
         } break;
         default: {
           DC_LOG_ERROR("Unknown probe type: %d", static_cast<int>(probe.type));


### PR DESCRIPTION
Fixes Associate custom probes to a different names to deduplicate intersecting functions Fixes #69