### PR TITLE
feat: Add MPI support and enhance job configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -321,7 +321,7 @@ foreach(_line ${_CAPTURE_PROBES_NAME_LINES})
     list(APPEND DATACRUMBS_CAPTURE_PROBES_LIST "${_probe_name}")
 endforeach()
 
-message(STATUS "[${UPPER_PROJECT_NAME}]  Capture probes: ${DATACRUMBS_CAPTURE_PROBES_LIST}")
+message(STATUS "[${UPPER_PROJECT_NAME}] Capture probes: ${DATACRUMBS_CAPTURE_PROBES_LIST}")
 
 list(APPEND DATACRUMBS_BPF_EXTRA_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/src/datacrumbs/server/bpf/common.c)
 list(APPEND DATACRUMBS_BPF_EXTRA_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/src/datacrumbs/server/bpf/init.bpf.c)

--- a/cmake/modules/datacrumbs-utils.cmake
+++ b/cmake/modules/datacrumbs-utils.cmake
@@ -24,6 +24,7 @@ macro(include_dependencies)
     find_package(LLVM REQUIRED CONFIG COMPONENTS Clang)
     find_package(json-c REQUIRED)
     find_package(ZLIB REQUIRED)
+    find_package(MPI REQUIRED COMPONENTS CXX QUIET)
 
     # all validator
     if(LIBBPF_VERSION VERSION_LESS "1.0.0")
@@ -109,6 +110,33 @@ macro(include_dependencies)
         message(FATAL_ERROR "-- [${UPPER_PROJECT_NAME}] zlib is needed for ${PROJECT_NAME} build")
     endif()
 
+    if(${MPI_CXX_FOUND})
+        # MPI_CXX_FOUND MPI_CXX_VERSION MPI_CXX_INCLUDE_DIRS MPI_CXX_LIBRARIES
+        get_filename_component(MPI_CXX_INCLUDE_DIRS "${MPI_CXX_INCLUDE_DIRS}" ABSOLUTE)
+        include_directories(${MPI_CXX_INCLUDE_DIRS})
+
+        if(NOT DEFINED MPI_CXX_LIBRARY_DIR)
+            if(MPI_CXX_LIBRARIES)
+                # If MPI_CXX_LIBRARIES is a list, get parent dir of each library
+                set(MPI_CXX_LIBRARY_DIR "")
+                foreach(_lib ${MPI_CXX_LIBRARIES})
+                    get_filename_component(_lib_dir "${_lib}" DIRECTORY)
+                    get_filename_component(_lib_dir "${_lib_dir}" ABSOLUTE)
+                    list(APPEND MPI_CXX_LIBRARY_DIR "${_lib_dir}")
+                endforeach()
+                list(REMOVE_DUPLICATES MPI_CXX_LIBRARY_DIR)
+            else()
+                get_filename_component(MPI_CXX_LIBRARY_DIR "${MPI_CXX_LIBRARIES}" DIRECTORY)
+                set(MPI_CXX_LIBRARY_DIR "${MPI_CXX_LIBRARY_DIR}")
+            endif()
+        endif()
+
+        list(APPEND DEPENDENCY_LIBRARY_DIRS ${MPI_CXX_LIBRARY_DIR})
+        set(DEPENDENCY_LIB ${DEPENDENCY_LIB} -L${MPI_CXX_LIBRARY_DIR} ${MPI_CXX_LIBRARIES})
+    else()
+        message(FATAL_ERROR "-- [${UPPER_PROJECT_NAME}] mpi is needed for ${PROJECT_NAME} build")
+    endif()
+
     list(APPEND DEPENDENCY_LIBRARY_DIRS ${DATACRUMBS_INSTALL_LIB_DIR})
     list(REMOVE_DUPLICATES DEPENDENCY_LIBRARY_DIRS)
 
@@ -118,11 +146,13 @@ macro(include_dependencies)
     message(STATUS "             - Found llvm:${LLVM_VERSION} at include:${LLVM_INCLUDE_DIRS} lib:${LLVM_LIBRARY_DIRS} clang:${CLANG_EXECUTABLE}")
     message(STATUS "             - Found json-c:${json-c_CONSIDERED_VERSIONS} at include:${json-c_INCLUDE_DIR} lib:${json-c_LIBRARY_DIR}")
     message(STATUS "             - Found zlib:${ZLIB_VERSION} at include:${ZLIB_INCLUDE_DIRS} lib:${ZLIB_LIBRARY_DIRS}")
+    message(STATUS "             - Found mpi:${MPI_CXX_VERSION} at include:${MPI_CXX_INCLUDE_DIRS} lib:${MPI_CXX_LIBRARY_DIR}")
     message(STATUS "             - DEPENDENCY_LIBRARY_DIRS for RPATH:${DEPENDENCY_LIBRARY_DIRS}")
     message(STATUS "             - DEPENDENCY_LIB for linking :${DEPENDENCY_LIB}")
 
     set(CMAKE_INSTALL_RPATH "${DEPENDENCY_LIBRARY_DIRS}")
     set(CMAKE_BUILD_RPATH "${DEPENDENCY_LIBRARY_DIRS}")
+    # print_all_variables()
 endmacro(include_dependencies)
 
 macro(derive_configurations)
@@ -332,7 +362,6 @@ function(datacrumbs_composable_install_headers public_headers)
     # message("-- [${PROJECT_NAME}] " "installing headers ${public_headers}")
     foreach(header ${public_headers})
         file(RELATIVE_PATH header_file_path "${PROJECT_SOURCE_DIR}/src" "${header}")
-        message("-- [${PROJECT_NAME}] " "installing header ${header_file_path}")
         get_filename_component(header_directory_path "${header_file_path}" DIRECTORY)
 
         # message(STATUS "             - Installing header ${header} to ${CMAKE_LIBEXEC_OUTPUT_DIRECTORY}/composable/include/${header_directory_path}")
@@ -350,7 +379,6 @@ function(datacrumbs_composable_install_src public_src)
     # message("-- [${PROJECT_NAME}] " "installing src files ${public_src}")
     foreach(src ${public_src})
         file(RELATIVE_PATH src_file_path "${PROJECT_SOURCE_DIR}/src" "${src}")
-        message("-- [${PROJECT_NAME}] " "installing src ${src_file_path}")
         get_filename_component(src_directory_path "${src_file_path}" DIRECTORY)
         install(
             FILES ${CMAKE_LIBEXEC_OUTPUT_DIRECTORY}/composable/src/${src_file_path}

--- a/etc/datacrumbs/configs/project.yaml.in
+++ b/etc/datacrumbs/configs/project.yaml.in
@@ -21,3 +21,8 @@ log:
   dir_pattern: @DATACRUMBS_CONFIGURED_LOG_DIR@/%YY%/%MM%/%DD%
 server:
   load_timeout: ${DATACRUMBS_SERVER_TIMEOUT_USER:-10}
+job:
+  run: flux run
+  node_flag: -N
+  ppn_flag: --tasks-per-node
+  other_flags:

--- a/infrastrutcure/docker/Dockerfile
+++ b/infrastrutcure/docker/Dockerfile
@@ -2,6 +2,19 @@ FROM hdevarajan92/datacrumbs:latest
 
 RUN mkdir -p /opt/datacrumbs
 COPY . /opt/datacrumbs/
+
+# Create a non-root user 'docker' with passwordless sudo access and install tools
+RUN (dnf -y install epel-release || yum -y install epel-release) && \
+    (dnf -y install sudo || yum -y install sudo) && \
+    (dnf -y install patchelf || yum -y install patchelf) && \
+    (dnf -y install openmpi-devel || yum -y install openmpi-devel) && \
+    (dnf clean all || yum clean all) && \
+    groupadd -f wheel && \
+    useradd -m -s /bin/bash docker && \
+    usermod -aG wheel docker && \
+    echo 'docker ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/docker && \
+    chmod 0440 /etc/sudoers.d/docker
+
 RUN . /opt/rh/gcc-toolset-11/enable && \
     mkdir -p datacrumbs-build && \
     rm -rf datacrumbs-build/* && \
@@ -10,24 +23,14 @@ RUN . /opt/rh/gcc-toolset-11/enable && \
           -DDATACRUMBS_USER=root \
           -DDATACRUMBS_INSTALL_USER=docker \
           -DDATACRUMBS_KERNEL_HEADERS_PATH=/usr/src/kernels/4.18.0-348.7.1.el8_5.x86_64 \
+          -DCMAKE_PREFIX_PATH=/usr/lib64/openmpi \
           -DCMAKE_INSTALL_PREFIX=/opt/datacrumbs-install \
           /opt/datacrumbs/ && \
     make -j $(nproc) && \
     make install
 
-ENV PATH=/opt/datacrumbs/datacrumbs-build/bin:${PATH}
-ENV LD_LIBRARY_PATH="/opt/datacrumbs/datacrumbs-build/lib:${LD_LIBRARY_PATH}":${LD_LIBRARY_PATH}
-
-# Create a non-root user 'docker' with passwordless sudo access and install tools
-RUN (dnf -y install epel-release || yum -y install epel-release) && \
-    (dnf -y install sudo || yum -y install sudo) && \
-    (dnf -y install patchelf || yum -y install patchelf) && \
-    (dnf clean all || yum clean all) && \
-    groupadd -f wheel && \
-    useradd -m -s /bin/bash docker && \
-    usermod -aG wheel docker && \
-    echo 'docker ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/docker && \
-    chmod 0440 /etc/sudoers.d/docker
+ENV PATH=/usr/lib64/openmpi/bin:/opt/datacrumbs/datacrumbs-build/bin:${PATH}
+ENV LD_LIBRARY_PATH=/usr/lib64/openmpi/lib:/opt/datacrumbs/datacrumbs-build/lib:${LD_LIBRARY_PATH}
 
 # Ensure docker user can access relevant directories under /opt
 RUN mkdir -p /opt/datacrumbs /opt/datacrumbs-install && \

--- a/scripts/datacrumbs/datacrumbs_args.in
+++ b/scripts/datacrumbs/datacrumbs_args.in
@@ -74,6 +74,7 @@ dc__bind_spec() {
     declare -gn T="__dc_${prefix}_types"
     declare -gn D="__dc_${prefix}_descs"
     declare -gn V="__dc_${prefix}_varnames"
+    declare -gn DF="__dc_${prefix}_defs"
     declare -gn IDX="__dc_${prefix}_index_by_name"
     declare -gn PN="__dc_${prefix}_pos_names"
     declare -gn PR="__dc_${prefix}_pos_reqs"
@@ -95,6 +96,7 @@ dc_args_init() {
     declare -ga "__dc_${prefix}_types=()"
     declare -ga "__dc_${prefix}_descs=()"
     declare -ga "__dc_${prefix}_varnames=()"
+    declare -ga "__dc_${prefix}_defs=()"
     declare -gA "__dc_${prefix}_index_by_name=()"
 
     # Positional arguments spec (names, req flags, descriptions, varnames)
@@ -114,40 +116,33 @@ dc_args_init() {
 
 # Core adder (nameref-based, reliable)
 dc__add_option_core() {
-    local prefix="$1" opt="$2" req="$3" desc="$4" type="$5" varname="$6"
+    local prefix="$1" opt="$2" req="$3" desc="$4" type="$5" varname="$6" default="${7-}"
     dc__bind_spec "$prefix"
-    # debug
-    # debug "[dc__add_option_core] prefix=$prefix opt=$opt var=$varname"
+    # Avoid duplicate option registration
     if [[ -n "${IDX[$opt]+_}" ]]; then
         return 0
     fi
     local i; i="${#N[@]}"
-    N[i]="$opt"; R[i]="$req"; T[i]="$type"; D[i]="$desc"; V[i]="$varname"
+    N[i]="$opt"; R[i]="$req"; T[i]="$type"; D[i]="$desc"; V[i]="$varname"; DF[i]="$default"
     IDX["$opt"]="$i"
-    # debug
-    # debug "[dc__add_option_core] N_len=${#N[@]} after adding $opt"
-    if [[ "$type" == "bool" ]]; then
-        dc__declvar_preserve "$varname" "0"
-    else
-        dc__declvar_preserve "$varname" ""
-    fi
+    # Do not force initial value; allow parse to set defaults and normalize
+    dc__declvar_preserve "$varname" ""
 }
-
 # Add an option to the spec: NAME MANDATORY|OPTIONAL DESCRIPTION [TYPE]
 # TYPE defaults to "string". Supported: string, int, bool
 dc_args_add_option() {
-    local prefix="$1" opt="$2" req="$3" desc="$4" type="${5:-string}"
-    [[ -z "$prefix" || -z "$opt" || -z "$req" ]] && { error "dc_args_add_option: missing args"; return 64; }
+    local prefix="$1" opt="$2" req="$3" desc="$4" type="${5:-string}" default="${6-}"
+    [[ -z "$prefix" || -z "$opt" || -z "$req" ]] && { error "dc_args_add_option: missing args"; exit 1; }
     case "$req" in
         MANDATORY|OPTIONAL) ;;
-        *) error "dc_args_add_option: req must be MANDATORY or OPTIONAL"; return 64;;
+        *) error "dc_args_add_option: req must be MANDATORY or OPTIONAL"; exit 1;;
     esac
     case "$type" in
         string|int|bool) ;;
-        *) error "dc_args_add_option: unsupported type '$type'"; return 64;;
+        *) error "dc_args_add_option: unsupported type '$type'"; exit 1;;
     esac
     local var; var="$(dc__make_var_name "$prefix" "$opt")"
-    dc__add_option_core "$prefix" "$opt" "$req" "$desc" "$type" "$var"
+    dc__add_option_core "$prefix" "$opt" "$req" "$desc" "$type" "$var" "$default"
 }
 
 # Add a positional argument to the spec: NAME MANDATORY|OPTIONAL DESCRIPTION
@@ -172,7 +167,7 @@ dc__add_global_bool() {
     dc__bind_spec "$prefix"
     if [[ -n "${IDX[$opt]+_}" ]]; then return 0; fi
     local var; var="$(dc__make_global_var_name "$opt")"
-    dc__add_option_core "$prefix" "$opt" "OPTIONAL" "$desc" "bool" "$var"
+    dc__add_option_core "$prefix" "$opt" "OPTIONAL" "$desc" "bool" "$var" ""
 }
 
 # Ensure the common inherited options exist for this prefix
@@ -254,10 +249,32 @@ dc_args_usage() {
         for ((i=0; i<${#N[@]}; ++i)); do
             if [[ "${R[i]}" == "$want" ]]; then
                 (( any==0 )) && { log "$header"; any=1; }
+                # Determine conditional requirement note based on subcommands
+                local note=""
+                if [[ -n "$SUBCMD_OPT" ]]; then
+                    local __vals=()
+                    local __k
+                    for __k in "${!SUBCMDS[@]}"; do
+                        local __opts_str="${SUBCMDS[$__k]}"
+                        IFS=',' read -ra __opts <<< "$__opts_str"
+                        local __o
+                        for __o in "${__opts[@]}"; do
+                            if [[ "$__o" == "${N[i]}" ]]; then
+                                __vals+=("$__k")
+                                break
+                            fi
+                        done
+                    done
+                    if (( ${#__vals[@]} > 0 )); then
+                        local __vals_joined
+                        IFS='|' read -r __vals_joined <<< "${__vals[*]}"
+                        note=" (required when --$SUBCMD_OPT=$__vals_joined)"
+                    fi
+                fi
                 if [[ "${T[i]}" == "bool" ]]; then
-                    log "  --%-18s %s\n" "${N[i]}" "${D[i]}"
+                    log "  --%-18s %s%s\n" "${N[i]}" "${D[i]}" "$note"
                 else
-                    log "  --%-18s %s\n" "${N[i]} <${T[i]}>" "${D[i]}"
+                    log "  --%-18s %s%s\n" "${N[i]} <${T[i]}>" "${D[i]}" "$note"
                 fi
             fi
         done
@@ -323,13 +340,25 @@ dc_args_parse() {
     for ((i=0; i<${#N[@]}; ++i)); do
         var="${V[i]}"
         if [[ "${T[i]}" == "bool" ]]; then
-            if [[ "${!var+x}" == x ]]; then
+            # If a non-empty value already exists (e.g., from environment), normalize it.
+            if [[ -n "${!var-}" ]]; then
                 dc__normalize_bool_var "$var"
             else
-                dc__setvar "$var" "0"
+                # Otherwise, initialize from default if provided; fallback to 0.
+                if [[ -n "${DF[i]-}" ]]; then
+                    dc__setvar "$var" "${DF[i]}"
+                    dc__normalize_bool_var "$var"
+                else
+                    dc__setvar "$var" "0"
+                fi
             fi
         else
-            dc__setvar "$var" ""
+            # Initialize non-bool to default if provided; else empty
+            if [[ -n "${DF[i]-}" ]]; then
+                dc__setvar "$var" "${DF[i]}"
+            else
+                dc__setvar "$var" ""
+            fi
         fi
     done
 
@@ -384,6 +413,8 @@ dc_args_parse() {
         exit 1
     fi
 
+    # Defaults were initialized prior to parsing; no further action needed here.
+
     if [[ "${HELP:-0}" == "1" ]]; then dc_args_show_help "$prefix" "$prog"; exit 0; fi
 
     if [[ "${QUIET:-0}" == "1" ]]; then dc__setvar "VERBOSE" "0"; fi
@@ -437,6 +468,10 @@ dc_args_parse() {
             fi
         fi
     fi
+
+    if [[ "${VERBOSE:-0}" == "1" ]]; then
+        dc_args_pretty_print "$prefix" "$prog"
+    fi
 }
 
 dc_args_pretty_print() {
@@ -451,20 +486,66 @@ dc_args_pretty_print() {
         for ((i=0; i<${#N[@]}; ++i)); do
             if [[ "${R[i]}" == "$want" ]]; then
                 (( any==0 )) && { debug "$header"; any=1; }
-                local var val; var="${V[i]}"; val="${!var}"
+                local var val disp; var="${V[i]}"; val="${!var}"; disp=""
+                # Compute conditional requirement note for this option (if any)
+                local note=""
+                if [[ -n "$SUBCMD_OPT" ]]; then
+                    local __vals=() __k
+                    for __k in "${!SUBCMDS[@]}"; do
+                        local __opts_str="${SUBCMDS[$__k]}"
+                        IFS=',' read -ra __opts <<< "$__opts_str"
+                        local __o
+                        for __o in "${__opts[@]}"; do
+                            if [[ "$__o" == "${N[i]}" ]]; then
+                                __vals+=("$__k")
+                                break
+                            fi
+                        done
+                    done
+                    if (( ${#__vals[@]} > 0 )); then
+                        local __joined=""; local __idx
+                        for __idx in "${!__vals[@]}"; do
+                            [[ "$__idx" -gt 0 ]] && __joined+="|"
+                            __joined+="${__vals[$__idx]}"
+                        done
+                        note=" (required when --$SUBCMD_OPT=$__joined)"
+                    fi
+                fi
+
                 if [[ "${T[i]}" == "bool" ]]; then
                     if [[ "$val" == "1" ]]; then val="true"; else val="false"; fi
-                    debug "  --%-*s : %s" "$max" "${N[i]}" "$val"
+                    debug "  --%-*s : %s%s" "$max" "${N[i]}" "$val" "$note"
                 else
-                    if [[ -z "$val" ]]; then debug "  --%-*s : %s" "$max" "${N[i]}" "";
-                    else local qv; debug -v qv "%q" "$val"; debug "  --%-*s : %s" "$max" "${N[i]}" "$qv"; fi
+                    # Prefer actual value; if empty, fall back to default (if any) for display
+                    if [[ -n "$val" ]]; then
+                        disp="$val"
+                    elif [[ -n "${DF[i]-}" ]]; then
+                        disp="${DF[i]}"
+                    else
+                        disp=""
+                    fi
+                    if [[ -z "$disp" ]]; then
+                        debug "  --%-*s : %s%s" "$max" "${N[i]}" "" "$note"
+                    else
+                        local qv
+                        printf -v qv "%q" "$disp"
+                        debug "  --%-*s : %s%s" "$max" "${N[i]}" "$qv" "$note"
+                    fi
                 fi
             fi
         done; (( any==1 )) && debug ""
     }
     print_group "MANDATORY" "Mandatory options:"; print_group "OPTIONAL"  "Optional options:"
     local argsvar; argsvar="$(echo -n "${prefix}_ARGS" | dc__upper)"; local -n __dc_args_ref="$argsvar"
-    if (( ${#__dc_args_ref[@]} > 0 )); then debug "Positional arguments:"; for ((i=0; i<${#__dc_args_ref[@]}; ++i)); do local q; debug -v q "%q" "${__dc_args_ref[i]}"; debug "  [%d] %s" "$i" "$q"; done; debug ""; fi
+    if (( ${#__dc_args_ref[@]} > 0 )); then
+        debug "Positional arguments:"
+        for ((i=0; i<${#__dc_args_ref[@]}; ++i)); do
+            local q
+            printf -v q "%q" "${__dc_args_ref[i]}"
+            debug "  [%d] %s" "$i" "$q"
+        done
+        debug ""
+    fi
 }
 
 # Example:
@@ -475,7 +556,7 @@ dc_args_pretty_print() {
 # dc_args_pretty_print "MYAPP" "myprog"
 # dc_args_usage "MYAPP" "myprog"
 # echo "$MYAPP_INPUT" "$MYAPP_COUNT" "$VERBOSE" "$QUIET" "$DRY_RUN"
-#
+#   
 # Example with subcommands:
 # dc_args_init "MYAPP"
 # dc_args_add_option "MYAPP" "user"   "MANDATORY" "User name" "string"

--- a/scripts/datacrumbs/datacrumbs_compose_run.in
+++ b/scripts/datacrumbs/datacrumbs_compose_run.in
@@ -15,6 +15,10 @@ source "$SCRIPT_DIR/datacrumbs_args"
 dc_args_init "DATACRUMBS_COMPOSE_RUN"
 dc_args_add_option "DATACRUMBS_COMPOSE_RUN" "composite_name" "MANDATORY" "Composable name" "string"
 dc_args_add_option "DATACRUMBS_COMPOSE_RUN" "app" "MANDATORY" "App command" "string"
+dc_args_add_option "DATACRUMBS_COMPOSE_RUN" "enable_mpi" "OPTIONAL" "switch to enable MPI" "bool" "0"
+dc_args_add_option "DATACRUMBS_COMPOSE_RUN" "nodes" "OPTIONAL" "Set number of nodes" "int" "1"
+dc_args_add_option "DATACRUMBS_COMPOSE_RUN" "ppn" "OPTIONAL" "Set processes per node" "int" "1"
+dc_args_add_subcommand "DATACRUMBS_COMPOSE_RUN" "enable_mpi" "1" "nodes" "ppn"
 # The rest of the arguments are arbitrary and will be captured as APP_ARGS
 
 
@@ -30,6 +34,9 @@ fi
 DATACRUMBS_COMPOSABLE_NAME="${DATACRUMBS_COMPOSE_RUN_COMPOSITE_NAME:-}"
 APP_CMD=("${DATACRUMBS_COMPOSE_RUN_APP}")
 PROG_NAME=$(basename "$0")
+export DATACRUMBS_JOB_ENABLE_MPI=${DATACRUMBS_COMPOSE_RUN_ENABLE_MPI:-0}
+export DATACRUMBS_JOB_NODES=${DATACRUMBS_COMPOSE_RUN_NODES:-1}
+export DATACRUMBS_JOB_PPN=${DATACRUMBS_COMPOSE_RUN_PPN:-1}
 
 if [[ -z "$DATACRUMBS_COMPOSABLE_NAME" ]]; then
     echo "Error: COMPOSITE_NAME argument is required."
@@ -65,13 +72,9 @@ READY_FILE="/tmp/datacrumbs_${DATACRUMBS_USER}_${RUNID}.ready"
 debug "Starting datacrumbs server with exec: ${exec[*]}"
 datacrumbs_start_server "${exec[*]}"
 
-if [[ "$DRY_RUN" == "1" ]]; then
-    log "[DRY_RUN] Would run App: ${APP_CMD[*]}"
-else
-    log "Running App: ${APP_CMD[*]}"
-    "${APP_CMD[@]}"
-    log "Finished App: ${APP_CMD[*]}"
-fi
+log "Running App: ${APP_CMD[*]}"
+job_launch "${APP_CMD[@]}"
+log "Finished App"
 
 debug "Stopping datacrumbs server with exec: ${exec[*]}"
 datacrumbs_stop_server "${exec[*]}" $PROG_NAME

--- a/scripts/datacrumbs/datacrumbs_run.in
+++ b/scripts/datacrumbs/datacrumbs_run.in
@@ -13,6 +13,11 @@ source "$SCRIPT_DIR/datacrumbs_args"
 
 dc_args_init "DATACRUMBS"
 dc_args_add_option "DATACRUMBS" "app" "MANDATORY" "App command" "string"
+dc_args_add_option "DATACRUMBS" "enable_mpi" "OPTIONAL" "switch to enable MPI" "bool" "0"
+dc_args_add_option "DATACRUMBS" "nodes" "OPTIONAL" "Set number of nodes" "int" "1"
+dc_args_add_option "DATACRUMBS" "ppn" "OPTIONAL" "Set processes per node" "int" "1"
+dc_args_add_subcommand "DATACRUMBS" "enable_mpi" "1" "nodes" "ppn"
+
 dc_args_parse "DATACRUMBS" "datacrumbs_run" "$@"
 
 if [[ $? -ne 0 ]]; then
@@ -26,6 +31,10 @@ if [[ -z "${DATACRUMBS_APP}" ]]; then
     show_help
     exit 1
 fi
+
+export DATACRUMBS_JOB_ENABLE_MPI=${DATACRUMBS_ENABLE_MPI:-0}
+export DATACRUMBS_JOB_NODES=${DATACRUMBS_NODES:-1}
+export DATACRUMBS_JOB_PPN=${DATACRUMBS_PPN:-1}
 
 # Convert APP_CMD string into array, splitting on spaces
 read -ra APP_CMD <<< "${DATACRUMBS_APP}"
@@ -46,12 +55,7 @@ READY_FILE="/tmp/datacrumbs_${DATACRUMBS_USER}_${RUNID}.ready"
 datacrumbs_start_server @CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_SBINDIR@/datacrumbs
 
 log "Running App: ${APP_CMD[*]}"
-log  "${APP_CMD[*]}"
-if [[ "$DRY_RUN" == "1" ]]; then
-    log "[DRY RUN] ${APP_CMD[*]}"
-else
-    "${APP_CMD[@]}"
-fi
+job_launch "${APP_CMD[@]}"
 log "Finished App"
 
 datacrumbs_stop_server @CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_SBINDIR@/datacrumbs $PROG_NAME

--- a/scripts/datacrumbs/datacrumbs_utility.in
+++ b/scripts/datacrumbs/datacrumbs_utility.in
@@ -77,14 +77,18 @@ function datacrumbs_start_server() {
   WAIT_INTERVAL=2
   ELAPSED=0
 
+  log "Starting Server: ${cmd[*]}"
   if [ "${DRY_RUN:-0}" -eq 1 ]; then
-    log "[DRY RUN] Would start server: ${cmd[@]}"
+    server_launch "${cmd[@]}"
+  else
+   server_launch "${cmd[@]}" > $DATACRUMBS_LOG_FILE 2>&1 &
+  fi
+
+  if [ "${DRY_RUN:-0}" -eq 1 ]; then
     log "[DRY RUN] Would wait for ready file: $READY_FILE (DATACRUMBS_SERVER_LOAD_TIMEOUT: $DATACRUMBS_SERVER_LOAD_TIMEOUT seconds)"
     return 0
   fi
 
-  log "Starting Server: ${cmd[*]}"
-  sudo "${cmd[@]}" > $DATACRUMBS_LOG_FILE 2>&1 &
 
   while [ ! -f "$READY_FILE" ]; do
       sleep $WAIT_INTERVAL
@@ -107,16 +111,20 @@ function datacrumbs_stop_server() {
   exec=($exec)
   common_cmd=("$DATACRUMBS_INSTALL_HOST" "--user" "$DATACRUMBS_USER" "--config_path" "$DATACRUMBS_INSTALL_CONFIGS_DIR" "--data_dir" "$DATACRUMBS_INSTALL_DATA_DIR" "--trace_log_dir" "$DATACRUMBS_TRACE_DIR" --run_id "$RUNID")
   cmd=("${exec[@]}" "stop" "${common_cmd[@]}")
+  
+
+  log "Stopping Server: ${cmd[*]}"
   if [ "${DRY_RUN:-0}" -eq 1 ]; then
-    log "[DRY RUN] Would stop server: ${cmd[*]}"
+    server_launch "${cmd[@]}"
+  else
+   server_launch "${cmd[@]}" > $DATACRUMBS_LOG_FILE 2>&1
+  fi
+  
+  if [ "${DRY_RUN:-0}" -eq 1 ]; then
     log "[DRY RUN] Would find and kill process(es) with RUNID ${RUNID}"
     log "[DRY RUN] Would remove ready file: $READY_FILE"
     return 0
   fi
-
-  log "Stopping Server: ${cmd[*]}"
-  sudo "${cmd[@]}" >> "${DATACRUMBS_LOG_FILE}" 2>&1
-
   SERVER_PID=$(ps aux | grep "${RUNID}" | grep -v grep | grep -v "${prog_name}" | awk '{print $2}')
   if [ -n "$SERVER_PID" ]; then
       log "Found process(es) with RUNID ${RUNID}: $SERVER_PID. Killing them."
@@ -170,6 +178,38 @@ function check_install_user() {
     error "DATACRUMBS_USER does not match DATACRUMBS_INSTALL_USER: ${DATACRUMBS_USER}"
     exit 1
   fi
+}
+
+function job_launch() {
+  local cmd=()
+  if [[ -z "${DATACRUMBS_JOB_ENABLE_MPI}" || "${DATACRUMBS_JOB_ENABLE_MPI}" == "1" ]]; then
+    debug "Launching job with MPI"
+    cmd=(${DATACRUMBS_JOB_RUN} "${DATACRUMBS_JOB_NODE_FLAG}" "${DATACRUMBS_JOB_NODES}" "${DATACRUMBS_JOB_PPN_FLAG}" "${DATACRUMBS_JOB_PPN}" ${DATACRUMBS_JOB_OTHER_FLAGS} "$@")
+  else
+    debug "Launching job without MPI"
+    cmd=("$@")
+  fi
+  if [ "${DRY_RUN:-0}" -eq 1 ]; then
+      log "[DRY RUN] Would launch job: ${cmd[*]}"
+      return 0
+    fi
+  "${cmd[@]}"
+}
+
+function server_launch() {
+  local cmd=()
+  if [[ -z "${DATACRUMBS_JOB_ENABLE_MPI}" || "${DATACRUMBS_JOB_ENABLE_MPI}" == "1" ]]; then
+    debug "Launching server with MPI"
+    cmd=(${DATACRUMBS_JOB_RUN} "${DATACRUMBS_JOB_NODE_FLAG}" "${DATACRUMBS_JOB_NODES}" "${DATACRUMBS_JOB_PPN_FLAG}" "1" ${DATACRUMBS_JOB_OTHER_FLAGS} "sudo" "$@")
+  else
+    debug "Launching server without MPI"
+    cmd=("$@")
+  fi
+  if [ "${DRY_RUN:-0}" -eq 1 ]; then
+    log "[DRY RUN] Would launch server: ${cmd[*]}"
+    return 0
+  fi
+  sudo "${cmd[@]}"
 }
 
 if command -v module &> /dev/null

--- a/src/datacrumbs/common/configuration_manager.cpp
+++ b/src/datacrumbs/common/configuration_manager.cpp
@@ -32,6 +32,7 @@
 /**
  * External headers
  */
+#include <mpi.h>
 #include <yaml-cpp/yaml.h>
 
 namespace datacrumbs {
@@ -129,6 +130,12 @@ ConfigurationManager::ConfigurationManager(int argc, char** argv, bool print,
       capture_probes(),
       user("datacrumbs"),
       run_id("0") {
+  int initialized;
+  int status = MPI_Initialized(&initialized);
+  if (status == MPI_SUCCESS && initialized == true) {
+    MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
+  }
   struct rlimit rl;
   if (getrlimit(RLIMIT_NOFILE, &rl) == 0) {
     rl.rlim_cur = rl.rlim_max;  // Set soft limit to hard limit
@@ -491,8 +498,7 @@ void ConfigurationManager::print_configurations() {
 void ConfigurationManager::derive_configurations() {
   DC_LOG_TRACE("[ConfigurationManager] Deriving configurations...");
 
-  pid_t pid = getpid();
-  DC_LOG_DEBUG("[ConfigurationManager] Process ID: %d", pid);
+  DC_LOG_DEBUG("[ConfigurationManager] Process ID: %d for rank: %d", getpid(), this->mpi_rank);
 
   // Use this->hostname (std::string) instead of local char array
   std::string hostname;
@@ -503,18 +509,17 @@ void ConfigurationManager::derive_configurations() {
   }
   hostname = hostname_buf;
   this->hostname = hostname;
-  DC_LOG_DEBUG("[ConfigurationManager] Hostname: %s", this->hostname.c_str());
+  DC_LOG_DEBUG("[ConfigurationManager] Hostname: %s for rank: %d", this->hostname.c_str(),
+               this->mpi_rank);
 
-  auto now = std::chrono::system_clock::now();
-  auto timestamp =
-      std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();
-  DC_LOG_DEBUG("[ConfigurationManager] Timestamp: %lld", static_cast<long long>(timestamp));
+  std::string generated_file_suffix = this->user + "-" + this->name + "-" +
+                                      std::to_string(this->mpi_rank) + "-" +
+                                      std::to_string(this->mpi_size) + "-" + this->run_id;
 
-  std::string trace_file_name = "trace-" + this->user + "-" + this->name + "-" + this->hostname +
-                                "-" + std::to_string(timestamp) + ".pfw.gz";
+  std::string trace_file_name = "trace-" + generated_file_suffix + ".pfw.gz";
   this->trace_file_path = this->trace_log_dir / trace_file_name;
-  DC_LOG_DEBUG("[ConfigurationManager] Trace file path: %s",
-               this->trace_file_path.string().c_str());
+  DC_LOG_DEBUG("[ConfigurationManager] Trace file path: %s for rank: %d",
+               this->trace_file_path.string().c_str(), this->mpi_rank);
 
   std::string hostname_str(this->name);
   // Remove digits from hostname for file naming
@@ -522,39 +527,42 @@ void ConfigurationManager::derive_configurations() {
                      hostname_str.end());
   DC_LOG_DEBUG("[ConfigurationManager] Hostname (digits removed): %s", hostname_str.c_str());
 
+  std::string lookup_file_suffix = std::string(DATACRUMBS_INSTALL_USER) + "-" + hostname_str;
+
   // Construct probe file name: probes-DATACRUMBS_INSTALL_USER-host.json
-  std::string probe_file_name =
-      "probes-" + std::string(DATACRUMBS_INSTALL_USER) + "-" + hostname_str + ".json";
+  std::string probe_file_name = "probes-" + lookup_file_suffix + ".json";
   this->probe_file_path = this->data_dir / probe_file_name;
-  DC_LOG_DEBUG("[ConfigurationManager] Probe file path: %s",
-               this->probe_file_path.string().c_str());
+  if (this->mpi_rank == 0)
+    DC_LOG_DEBUG("[ConfigurationManager] Probe file path: %s",
+                 this->probe_file_path.string().c_str());
 
   // Construct probe exclusion file name: probes-exclusion-DATACRUMBS_INSTALL_USER-host.json
-  std::string probe_exclusion_file_name =
-      "probes-exclusion-" + std::string(DATACRUMBS_INSTALL_USER) + "-" + hostname_str + ".json";
+  std::string probe_exclusion_file_name = "probes-exclusion-" + lookup_file_suffix + ".json";
   this->probe_exclusion_file_path = this->data_dir / probe_exclusion_file_name;
-  DC_LOG_DEBUG("[ConfigurationManager] Probe exclusion file path: %s",
-               this->probe_exclusion_file_path.string().c_str());
+  if (this->mpi_rank == 0)
+    DC_LOG_DEBUG("[ConfigurationManager] Probe exclusion file path: %s",
+                 this->probe_exclusion_file_path.string().c_str());
 
   // Construct probe invalid file name: probes-invalid-DATACRUMBS_INSTALL_USER-host.json
-  std::string probe_invalid_file_name =
-      "probes-invalid-" + std::string(DATACRUMBS_INSTALL_USER) + "-" + hostname_str + ".json";
+  std::string probe_invalid_file_name = "probes-invalid-" + lookup_file_suffix + ".json";
   this->probe_invalid_file_path = this->data_dir / probe_invalid_file_name;
-  DC_LOG_DEBUG("[ConfigurationManager] Probe invalid path: %s",
-               this->probe_invalid_file_path.string().c_str());
+  if (this->mpi_rank == 0)
+    DC_LOG_DEBUG("[ConfigurationManager] Probe invalid path: %s",
+                 this->probe_invalid_file_path.string().c_str());
 
   // Construct categories file name: categories-DATACRUMBS_INSTALL_USER-host.json
-  std::string categories_file_name = "categories-" + user + "-" + hostname_str + ".json";
+  std::string categories_file_name = "categories-" + lookup_file_suffix + ".json";
   this->category_map_path = this->data_dir / categories_file_name;
-  DC_LOG_DEBUG("[ConfigurationManager] Category map path: %s",
-               this->category_map_path.string().c_str());
+  if (this->mpi_rank == 0)
+    DC_LOG_DEBUG("[ConfigurationManager] Category map path: %s",
+                 this->category_map_path.string().c_str());
 
   // Construct manual probe file name: manual-probes-DATACRUMBS_INSTALL_USER-host.json
-  std::string manual_probe_file_name =
-      "manual-probes-" + std::string(DATACRUMBS_INSTALL_USER) + "-" + hostname_str + ".json";
+  std::string manual_probe_file_name = "manual-probes-" + lookup_file_suffix + ".json";
   this->manual_probe_path = this->data_dir / manual_probe_file_name;
-  DC_LOG_DEBUG("[ConfigurationManager] Manual probe path: %s",
-               this->manual_probe_path.string().c_str());
+  if (this->mpi_rank == 0)
+    DC_LOG_DEBUG("[ConfigurationManager] Manual probe path: %s",
+                 this->manual_probe_path.string().c_str());
 
   // Load category_map from JSON file using json-c
   std::string category_json_path = category_map_path.string();
@@ -562,7 +570,8 @@ void ConfigurationManager::derive_configurations() {
     // Read file into string
     std::ifstream file(category_json_path);
     if (!file) {
-      DC_LOG_ERROR("Failed to open category map file: %s", category_json_path.c_str());
+      DC_LOG_ERROR("Failed to open category map file: %s for rank: %d", category_json_path.c_str(),
+                   this->mpi_rank);
       throw std::invalid_argument("Failed to open category map file: " + category_json_path);
     }
     std::string json_str((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
@@ -571,7 +580,8 @@ void ConfigurationManager::derive_configurations() {
     // Parse JSON
     struct json_object* root = json_tokener_parse(json_str.c_str());
     if (!root) {
-      DC_LOG_ERROR("Failed to parse JSON from %s", category_json_path.c_str());
+      DC_LOG_ERROR("Failed to parse JSON from %s for rank: %d", category_json_path.c_str(),
+                   this->mpi_rank);
       throw std::invalid_argument("Failed to parse JSON from: " + category_json_path);
     }
 
@@ -594,8 +604,8 @@ void ConfigurationManager::derive_configurations() {
     }
     json_object_put(root);
   } else {
-    DC_LOG_WARN("[ConfigurationManager] Category map file does not exist: %s",
-                category_json_path.c_str());
+    DC_LOG_WARN("[ConfigurationManager] Category map file does not exist: %s for rank: %d",
+                category_json_path.c_str(), this->mpi_rank);
   }
 }
 
@@ -607,18 +617,20 @@ void ConfigurationManager::derive_configurations() {
  */
 void ConfigurationManager::validate_configurations() {
   if (this->capture_probes.empty()) {
-    DC_LOG_ERROR("[ConfigurationManager] No capture probes defined in the configuration.");
+    DC_LOG_ERROR(
+        "[ConfigurationManager] No capture probes defined in the configuration for rank: %d.",
+        this->mpi_rank);
     throw std::invalid_argument("At least one capture probe must be defined.");
   }
   if (this->data_dir.empty() || !std::filesystem::exists(this->data_dir)) {
-    DC_LOG_ERROR("[ConfigurationManager] Data directory does not exist: %s",
-                 this->data_dir.string().c_str());
+    DC_LOG_ERROR("[ConfigurationManager] Data directory does not exist: %s for rank: %d.",
+                 this->data_dir.string().c_str(), this->mpi_rank);
     throw std::runtime_error("Data directory does not exist: " + this->data_dir.string());
   }
   if (this->trace_log_dir.empty() ||
       !std::filesystem::exists(std::filesystem::path(this->trace_log_dir))) {
-    DC_LOG_ERROR("[ConfigurationManager] Trace log directory does not exist: %s",
-                 this->trace_log_dir.string().c_str());
+    DC_LOG_ERROR("[ConfigurationManager] Trace log directory does not exist: %s for rank: %d.",
+                 this->trace_log_dir.string().c_str(), this->mpi_rank);
     throw std::runtime_error("Trace log directory does not exist: " +
                              std::filesystem::path(this->trace_log_dir).string());
   }

--- a/src/datacrumbs/common/configuration_manager.h
+++ b/src/datacrumbs/common/configuration_manager.h
@@ -84,7 +84,14 @@ class ConfigurationManager {
   // Derived configuration: current hostname
   std::string hostname;
 
-  std::string run_id;  // Unique run identifier
+  // Unique run identifier
+  std::string run_id;
+
+  // MPI rank of the current process
+  int mpi_rank{0};
+
+  // MPI size (total number of processes)
+  int mpi_size{1};
 
   /**
    * @brief Constructor that initializes the ConfigurationManager with command-line arguments.

--- a/src/datacrumbs/server/process/event_processor.cpp
+++ b/src/datacrumbs/server/process/event_processor.cpp
@@ -4,7 +4,7 @@
 #include <datacrumbs/common/configuration_manager.h>
 #include <datacrumbs/common/constants.h>
 #include <datacrumbs/common/data_structures.h>
-#include <datacrumbs/common/logging.h>  // Logging header
+#include <datacrumbs/common/logging.h>
 #include <datacrumbs/common/singleton.h>
 #include <datacrumbs/common/typedefs.h>
 #include <datacrumbs/common/utils.h>
@@ -14,10 +14,14 @@
 #include <datacrumbs/server/process/processing/general_event.h>
 #include <datacrumbs/server/process/processing/usdt_event.h>
 // Include generated
+#include <datacrumbs/datacrumbs_config.h>
 #include <datacrumbs/server/process/generated_process.h>
+// dependency headers
+#include <json-c/json.h>
+#include <mpi.h>
+
 // std headers
 #include <fcntl.h>
-#include <json-c/json.h>
 #include <limits.h>
 #include <stdlib.h>
 #include <sys/stat.h>
@@ -33,9 +37,6 @@
 #include <fstream>
 #include <iostream>
 #include <string>
-
-#include "datacrumbs/common/logging.h"
-#include "datacrumbs/datacrumbs_config.h"
 
 #define GET_DATA_FUNCTION(INDEX)                                       \
   auto write_event = get_data_##INDEX(data, event_index.fetch_add(1)); \
@@ -149,7 +150,7 @@ int EventProcessor::handle_event(void* data, size_t data_sz) {
   DC_LOG_TRACE("handle_event: end");
   std::string progress_msg =
       "Processed events failed: " + std::to_string(failed_events) + " current:";
-  DC_LOG_PROGRESS_SINGLE(progress_msg.c_str(), event_index);
+  if (configManager_->mpi_rank == 0) DC_LOG_PROGRESS_SINGLE(progress_msg.c_str(), event_index);
   return 0;
 }
 int EventProcessor::update_filename(const char* filename, unsigned int hash) {

--- a/src/datacrumbs/server/process/server.impl.cpp
+++ b/src/datacrumbs/server/process/server.impl.cpp
@@ -1,9 +1,11 @@
+// Internal headers
+#include <datacrumbs/common/enumerations.h>
 #include <datacrumbs/server/process/event_processor.h>
-
+// dependent headers
+#include <mpi.h>
+// std headers
 #include <algorithm>
 #include <string>
-
-#include "datacrumbs/common/enumerations.h"
 
 // Custom libbpf print function for debugging
 static int libbpf_print_fn(enum libbpf_print_level level, const char* format, va_list args) {
@@ -508,22 +510,29 @@ static int main_process(int argc, char** argv, datacrumbs::EventProcessor* event
     return 1;
   }
   double elapsed = timer.pauseTime();
-  DC_LOG_PRINT("Initialization of DataCrumbs elapsed time: %f seconds", elapsed);
+
+  if (event_processor->configManager_->mpi_rank == 0) {
+    DC_LOG_PRINT("Initialization of DataCrumbs elapsed time: %f seconds", elapsed);
+  }
 
   if (notify_parent) daemon_notify_parent();
   // Main event polling loop
   signal(SIGINT, sig_handler);
-  std::string ready_file = "/tmp/datacrumbs_" + event_processor->configManager_->user + "_" +
-                           event_processor->configManager_->run_id + ".ready";
-  std::ofstream ofs_ready(ready_file);
-  ofs_ready << "ready" << std::endl;
-  ofs_ready.close();
-  auto pwd = getpwnam(event_processor->configManager_->user.c_str());
-  uid_t uid = pwd ? pwd->pw_uid : static_cast<uid_t>(-1);
-  gid_t gid = pwd ? pwd->pw_gid : static_cast<gid_t>(-1);
-  chown(ready_file.c_str(), uid, gid);
-  chmod(ready_file.c_str(), 0660);
-  DC_LOG_PRINT("Server running on %d. Ready to run the code.", getpid());
+  if (event_processor->configManager_->mpi_rank == 0) {
+    std::string ready_file = "/tmp/datacrumbs_" + event_processor->configManager_->user + "_" +
+                             event_processor->configManager_->run_id + ".ready";
+    std::ofstream ofs_ready(ready_file);
+    ofs_ready << "ready" << std::endl;
+    ofs_ready.close();
+    auto pwd = getpwnam(event_processor->configManager_->user.c_str());
+    uid_t uid = pwd ? pwd->pw_uid : static_cast<uid_t>(-1);
+    gid_t gid = pwd ? pwd->pw_gid : static_cast<gid_t>(-1);
+    chown(ready_file.c_str(), uid, gid);
+    chmod(ready_file.c_str(), 0660);
+    DC_LOG_PRINT("Server running on %d nodes. Ready to run the code.",
+                 event_processor->configManager_->mpi_size);
+  }
+  MPI_Barrier(MPI_COMM_WORLD);
 
   unsigned int batch_size = 1024;
 #if defined(DATACRUMBS_BPFTIME_COMPATIBLE_FLAG) && (DATACRUMBS_BPFTIME_COMPATIBLE_FLAG == 0)
@@ -676,13 +685,15 @@ static int main_process(int argc, char** argv, datacrumbs::EventProcessor* event
 #if defined(DATACRUMBS_MODE) && (DATACRUMBS_MODE == 1)
   int failed_events = 0;
   err = bpf_map_lookup_elem(failed_events_fd, &DATACRUMBS_FAILED_EVENTS_KEY, &failed_events);
-  if (err == 0) {
+  if (err == 0 && event_processor->configManager_->mpi_rank == 0) {
     DC_LOG_PRINT("Total %d events failed", failed_events);
   }
 #endif
 
 #if defined(DATACRUMBS_BPFTIME_COMPATIBLE_FLAG) && (DATACRUMBS_BPFTIME_COMPATIBLE_FLAG == 0)
-  DC_LOG_PRINT("Collecting string metadata from file_map...");
+  if (event_processor->configManager_->mpi_rank == 0) {
+    DC_LOG_PRINT("Collecting string metadata from file_map...");
+  }
   while (lookup_and_delete(file_hash_fd, event_processor, keys, values, batch_size, in_batch) ==
          1) {
     // Continue until no more keys are found
@@ -694,7 +705,9 @@ static int main_process(int argc, char** argv, datacrumbs::EventProcessor* event
     free(values);
   }
 #endif
-  DC_LOG_PRINT("Finalizing DataCrumbs...");
+  if (event_processor->configManager_->mpi_rank == 0) {
+    DC_LOG_PRINT("Finalizing DataCrumbs...");
+  }
   if (stop) {
     DC_LOG_INFO("Received SIGINT (Ctrl-C), exiting gracefully");
   }
@@ -711,57 +724,86 @@ static int main_process(int argc, char** argv, datacrumbs::EventProcessor* event
   datacrumbs_bpf__destroy(skel);
 
   double finalize_elapsed = timer.pauseTime();
-  DC_LOG_PRINT(
-      "Finalization and cleanup of DataCrumbs elapsed time: %f seconds with error code: %d",
-      finalize_elapsed, err);
-
-  // Write status info to JSON file for postprocessing
-
-  std::string status_file = "/tmp/datacrumbs_" + event_processor->configManager_->user +
-                            "_status_" + event_processor->configManager_->run_id + ".json";
-  struct json_object* status_json = json_object_new_object();
-  json_object_object_add(
-      status_json, "trace_file",
-      json_object_new_string(event_processor->configManager_->trace_file_path.c_str()));
-  json_object_object_add(status_json, "total_events_captured",
-                         json_object_new_int64(event_processor->event_index.load()));
-  json_object_object_add(status_json, "events_failed",
-                         json_object_new_int(event_processor->failed_events));
-
-  if (json_object_to_file_ext(status_file.c_str(), status_json, JSON_C_TO_STRING_PRETTY) != 0) {
-    DC_LOG_ERROR("Failed to write status file: %s", status_file.c_str());
+  double sum_elapsed = 0.0, min_elapsed = 0.0, max_elapsed = 0.0;
+  MPI_Reduce(&finalize_elapsed, &sum_elapsed, 1, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
+  MPI_Reduce(&finalize_elapsed, &min_elapsed, 1, MPI_DOUBLE, MPI_MIN, 0, MPI_COMM_WORLD);
+  MPI_Reduce(&finalize_elapsed, &max_elapsed, 1, MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD);
+  if (event_processor->configManager_->mpi_rank == 0) {
+    DC_LOG_PRINT("Finalization and cleanup of DataCrumbs: average=%f, min=%f, max=%f over %d ranks",
+                 sum_elapsed / event_processor->configManager_->mpi_size, min_elapsed, max_elapsed,
+                 event_processor->configManager_->mpi_size);
   }
-  json_object_put(status_json);
-  pwd = getpwnam(event_processor->configManager_->user.c_str());
-  uid = pwd ? pwd->pw_uid : static_cast<uid_t>(-1);
-  gid = pwd ? pwd->pw_gid : static_cast<gid_t>(-1);
-  chown(status_file.c_str(), uid, gid);
-  chmod(status_file.c_str(), 0660);
+
+  // Gather failed_events and total_events across all ranks
+  int local_failed_events = event_processor->failed_events;
+  int global_failed_events_sum = 0, global_failed_events_min = 0, global_failed_events_max = 0;
+  MPI_Reduce(&local_failed_events, &global_failed_events_sum, 1, MPI_INT, MPI_SUM, 0,
+             MPI_COMM_WORLD);
+  MPI_Reduce(&local_failed_events, &global_failed_events_min, 1, MPI_INT, MPI_MIN, 0,
+             MPI_COMM_WORLD);
+  MPI_Reduce(&local_failed_events, &global_failed_events_max, 1, MPI_INT, MPI_MAX, 0,
+             MPI_COMM_WORLD);
+
+  int local_total_events = static_cast<int>(event_processor->event_index.load());
+  int global_total_events_sum = 0, global_total_events_min = 0, global_total_events_max = 0;
+  MPI_Reduce(&local_total_events, &global_total_events_sum, 1, MPI_INT, MPI_SUM, 0, MPI_COMM_WORLD);
+  MPI_Reduce(&local_total_events, &global_total_events_min, 1, MPI_INT, MPI_MIN, 0, MPI_COMM_WORLD);
+  MPI_Reduce(&local_total_events, &global_total_events_max, 1, MPI_INT, MPI_MAX, 0, MPI_COMM_WORLD);
+
+  if (event_processor->configManager_->mpi_rank == 0) {
+    DC_LOG_PRINT("Failed events: sum=%d, min=%d, max=%d", global_failed_events_sum,
+                 global_failed_events_min, global_failed_events_max);
+    DC_LOG_PRINT("Total events: sum=%d, min=%d, max=%d", global_total_events_sum,
+                 global_total_events_min, global_total_events_max);
+    // Write status info to JSON file for postprocessing
+    std::string status_file = "/tmp/datacrumbs_" + event_processor->configManager_->user +
+                              "_status_" + event_processor->configManager_->run_id + ".json";
+    struct json_object* status_json = json_object_new_object();
+    json_object_object_add(
+        status_json, "trace_file",
+        json_object_new_string(event_processor->configManager_->trace_file_path.c_str()));
+    json_object_object_add(status_json, "total_events_captured",
+                           json_object_new_int64(event_processor->event_index.load()));
+    json_object_object_add(status_json, "events_failed",
+                           json_object_new_int(event_processor->failed_events));
+
+    if (json_object_to_file_ext(status_file.c_str(), status_json, JSON_C_TO_STRING_PRETTY) != 0) {
+      DC_LOG_ERROR("Failed to write status file: %s", status_file.c_str());
+    }
+    json_object_put(status_json);
+    auto pwd = getpwnam(event_processor->configManager_->user.c_str());
+    auto uid = pwd ? pwd->pw_uid : static_cast<uid_t>(-1);
+    auto gid = pwd ? pwd->pw_gid : static_cast<gid_t>(-1);
+    chown(status_file.c_str(), uid, gid);
+    chmod(status_file.c_str(), 0660);
+  }
 
   DC_LOG_TRACE("main: end");
   return 0;
 }
 
 static int main_call(int argc, char** argv) {
+  MPI_Init(&argc, &argv);
   auto event_processor = datacrumbs::EventProcessor(argc, argv);
   std::string hostname = get_hostname();
   std::string pidfile =
       "/tmp/datacrumbs_" + hostname + "_" + event_processor.configManager_->run_id + ".pid";
 
   int return_code = 0;
-  if (event_processor.configManager_->exe_mode == datacrumbs::ExecutableMode::RUN) {
+  if (event_processor.configManager_->mpi_rank == 0 &&
+      event_processor.configManager_->exe_mode != datacrumbs::ExecutableMode::STOP) {
     event_processor.configManager_->print_configurations();
+  }
+  if (event_processor.configManager_->exe_mode == datacrumbs::ExecutableMode::RUN) {
     write_pid_file(pidfile, event_processor.configManager_->user);
     return_code = main_process(argc, argv, &event_processor, false);
   } else if (event_processor.configManager_->exe_mode == datacrumbs::ExecutableMode::START) {
     daemonize();
-    auto event_processor = datacrumbs::EventProcessor(argc, argv);
     std::string logfile = event_processor.configManager_->log_dir + "/datacrumbs_" + hostname +
                           "_" + event_processor.configManager_->run_id + ".log";
     redirect_output(logfile, event_processor.configManager_->user);
     DC_LOG_PRINT("Spawned daemon with pid %d, output redirected to %s\n", getpid(),
                  logfile.c_str());
-    event_processor.configManager_->print_configurations();
     write_pid_file(pidfile, event_processor.configManager_->user);
     return_code = main_process(argc, argv, &event_processor, true);
   } else if (event_processor.configManager_->exe_mode == datacrumbs::ExecutableMode::STOP) {
@@ -782,8 +824,10 @@ static int main_call(int argc, char** argv) {
         if (!user) {
           user = "unknown";
         }
-        DC_LOG_PRINT("Sent SIGINT as %s. Waiting for %f minutes for pid:%d to exit", user,
-                     max_retries / 60.0, pid);
+        if (event_processor.configManager_->mpi_rank == 0) {
+          DC_LOG_PRINT("Sent SIGINT as %s. Waiting for %f minutes for pid:%d to exit", user,
+                       max_retries / 60.0, pid);
+        }
         int i;
         for (i = 0; i < max_retries; ++i) {
           std::string ps_cmd = "ps -p " + std::to_string(pid) + " > /dev/null";
@@ -794,19 +838,25 @@ static int main_call(int argc, char** argv) {
           }
           usleep(1000000);  // Sleep 1s
         }
-        if (access(pidfile.c_str(), F_OK) == 0) {
-          remove(pidfile.c_str());
-        }
         if (i == max_retries) {
-          DC_LOG_PRINT("Process %d did not terminate within the expected time.", pid);
+          DC_LOG_PRINT("Process %d did not terminate within the expected time for rank %d.", pid,
+                       event_processor.configManager_->mpi_rank);
           return_code = 1;
         } else {
-          DC_LOG_PRINT("Process %d has terminated.", pid);
+          if (event_processor.configManager_->mpi_rank == 0) {
+            DC_LOG_PRINT("Process %d has terminated.", pid);
+          }
         }
       }
+      MPI_Barrier(MPI_COMM_WORLD);
+      if (access(pidfile.c_str(), F_OK) == 0) {
+        remove(pidfile.c_str());
+      }
     } else {
-      DC_LOG_ERROR("Could not find pid to stop.\n");
+      DC_LOG_ERROR("Could not find pid to stop on rank %d.\n",
+                   event_processor.configManager_->mpi_rank);
     }
   }
+  MPI_Finalize();
   return (return_code);
 }


### PR DESCRIPTION
- Introduced MPI support in the configuration manager, including rank and size tracking.
- Updated job launch logic to conditionally enable MPI based on user input.
- Enhanced argument parsing to include options for enabling MPI, setting the number of nodes, and processes per node.
- Modified server and job launch functions to handle MPI configurations.
- Improved logging to include rank-specific information for better traceability in MPI environments.
- Adjusted file naming conventions to incorporate MPI rank and size for generated files.
- Ensured that only the root rank logs certain messages to reduce clutter in multi-process scenarios.